### PR TITLE
[feature] Custom config; support custom currency, auto-select only exchange, auto-select all markets.

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -1,0 +1,6 @@
+{
+  "esversion": 6,
+  "asi": true,
+  "laxcomma": true,
+  "expr": true
+}

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -1,11 +1,20 @@
 #!/usr/bin/env node
 
+const fs = require('fs');
 const CFonts = require('cfonts')
 const args = require('../libs/args')
 const prompt = require('../libs/prompt')
 const Whale = require('../index')
 
-prompt.then((answer) => {
+let exchangers = require('../config/exchangers.json');
+if (args.config) {
+  if (!fs.existsSync(args.config)) {
+    return console.error(`config file ${args.config} does not exist`);
+  }
+  exchangers = require(args.config);
+}
+
+prompt(exchangers).then((answer) => {
   CFonts.say('Whale, show Ethereum and Bitcoin price in command line interface (CLI).|Loading...', {
     font: 'console',
     align: 'left',
@@ -16,5 +25,7 @@ prompt.then((answer) => {
     maxLength: '0'
   })
 
-  new Whale(args, answer.exchange, answer.markets)
-})
+  const exchange = exchangers[answer.exchange];
+  exchange.name = answer.exchange;
+  new Whale(args.seconds, exchange, answer.markets)
+}).catch(console.log)

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -14,7 +14,7 @@ if (args.config) {
   exchangers = require(args.config);
 }
 
-prompt(exchangers).then((answer) => {
+prompt(exchangers, args.all).then((answer) => {
   CFonts.say('Whale, show Ethereum and Bitcoin price in command line interface (CLI).|Loading...', {
     font: 'console',
     align: 'left',
@@ -25,7 +25,9 @@ prompt(exchangers).then((answer) => {
     maxLength: '0'
   })
 
+  // Init whale with selected exchange.
   const exchange = exchangers[answer.exchange];
   exchange.name = answer.exchange;
+
   new Whale(args.seconds, exchange, answer.markets)
-}).catch(console.log)
+}).catch(console.error)

--- a/config/exchangers.example.kraken_eur.json
+++ b/config/exchangers.example.kraken_eur.json
@@ -1,0 +1,66 @@
+{
+  "Yunbi": {
+    "currency": "¥",
+    "markets": {
+      "BTC": "btccny",
+      "ETH": "ethcny",
+      "ETC": "etccny",
+      "ZEC": "zeccny",
+      "DGD": "dgdcny",
+      "1ST": "1stcny",
+      "REP": "repcny",
+      "SC":"sccny"
+    },
+    "ticker": "https://yunbi.com/api/v2/tickers.json",
+    "kendpoint": "https://yunbi.com/api/v2/k.json",
+    "periods": [5, 60, 1440, 10080]
+  },
+  "Poloniex": {
+    "currency": "$",
+    "markets": {
+      "BTC": "USDT_BTC",
+      "ETH": "USDT_ETH",
+      "ETC": "USDT_ETC",
+      "ZEC": "USDT_ZEC",
+      "REP": "USDT_REP",
+      "LTC": "USDT_LTC"
+    },
+    "ticker": "https://poloniex.com/public?command=returnTicker",
+    "kendpoint": "https://poloniex.com/public?command=returnChartData",
+    "periods": [5, 120, 240, 1440]
+  },
+  "Kraken": {
+    "currency": "€",
+    "markets": {
+      "BTC": "XXBTZEUR",
+      "ETH": "XETHZEUR",
+      "ETC": "XETCZEUR",
+      "ZEC": "XZECZEUR",
+      "REP": "XREPZEUR"
+    },
+    "ticker": "https://api.kraken.com/0/public/Ticker",
+    "kendpoint": "https://api.kraken.com/0/public/OHLC",
+    "periods": [5, 60, 1440, 10080]
+  },
+  "Bitfinex": {
+    "currency": "$",
+    "markets": {
+      "BTC": "tBTCUSD",
+      "ETH": "tETHUSD",
+      "ETC": "tETCUSD",
+      "ZEC": "tZECUSD",
+      "LTC": "tLTCUSD"
+    },
+    "ticker": "https://api.bitfinex.com/v2/ticker",
+    "kendpoint": "https://api.bitfinex.com/v2/candles/trade",
+    "period": ["1m", "5m", "15m", "30m", "1h", "3h", "6h", "12h", "1D", "7D", "14D", "1M"]
+  },
+  "Coinbase": {
+    "currency": "$",
+    "markets": {
+      "BTC": "BTC-USD"
+    },
+    "ticker": "https://api.gdax.com/products",
+    "kendpoint": "https://api.gdax.com/products"
+  }
+}

--- a/config/exchangers.example.kraken_only_eur.json
+++ b/config/exchangers.example.kraken_only_eur.json
@@ -1,0 +1,15 @@
+{
+  "Kraken": {
+    "currency": "€",
+    "markets": {
+      "BTC": "XXBTZEUR",
+      "ETH": "XETHZEUR",
+      "ETC": "XETCZEUR",
+      "ZEC": "XZECZEUR",
+      "REP": "XREPZEUR"
+    },
+    "ticker": "https://api.kraken.com/0/public/Ticker",
+    "kendpoint": "https://api.kraken.com/0/public/OHLC",
+    "periods": [5, 60, 1440, 10080]
+  }
+}

--- a/index.js
+++ b/index.js
@@ -3,10 +3,9 @@ const contrib = require('blessed-contrib')
 const api = require('./libs/api')
 const utils = require('./libs/utils')
 const wash = require('./libs/wash')
-const exchangers = require('./config/exchangers')
 
 class Whale {
-  constructor(args, exchange, markets) {
+  constructor(interval, exchange, markets) {
     this.cacheData = {}
 
     this.fetchPrice(exchange, markets).then((data) => {
@@ -15,7 +14,7 @@ class Whale {
       this.cacheData = data
 
       this.initDashBoard(data, exchange)
-      this.eventListeners(args, exchange, markets)
+      this.eventListeners(interval, exchange, markets)
     }).catch((err) => {
       console.error('fetchPrice', err)
       process.exit(1)
@@ -48,7 +47,7 @@ class Whale {
       , selectedFg: 'white'
       , selectedBg: 'cyan'
       , interactive: true
-      , label: `${exchange} -- Current Price`
+      , label: `${exchange.name} -- Current Price`
       , border: { type: "line", fg: "cyan" }
       , columnSpacing: 10
       , columnWidth: [10, 10, 10] })
@@ -67,7 +66,7 @@ class Whale {
     this.createLog(utils.formatCurrentTime())
   }
 
-  eventListeners(args, exchange, markets) {
+  eventListeners(interval, exchange, markets) {
     this.timer = setInterval(() => {
       this.createLog('Loading...')
       api.getCurrentPrice(exchange, markets).then((res) => {
@@ -77,7 +76,7 @@ class Whale {
         console.error(`\n Load failure: ${err}`)
         process.exit(1)
       })
-    }, 1000 * (Number.isInteger(args.seconds) ? args.seconds : 180))
+    }, 1000 * (Number.isInteger(interval) ? interval : 180))
 
     this.table.rows.on('select', (item, selectedIndex) => {
       this.updatePriceTrend(exchange, this.cacheData.currentPrice[selectedIndex][0])

--- a/index.js
+++ b/index.js
@@ -7,13 +7,11 @@ const wash = require('./libs/wash')
 class Whale {
   constructor(interval, exchange, markets) {
     this.cacheData = {}
-    this.cacheExchange = {}
 
     this.fetchPrice(exchange, markets).then((data) => {
       this.screen = blessed.screen()
       this.grid = new contrib.grid({ rows: 12, cols: 12, screen: this.screen })
       this.cacheData = data
-      this.cacheExchange = exchange;
 
       this.initDashBoard(data, exchange)
       this.eventListeners(interval, exchange, markets)
@@ -86,7 +84,7 @@ class Whale {
 
     this.screen.on('resize', () => {
       utils.throttle(() => {
-        this.initDashBoard(this.cacheData, this.cacheExchange)
+        this.initDashBoard(this.cacheData, exchange)
       }, 360)()
     })
 

--- a/index.js
+++ b/index.js
@@ -7,11 +7,13 @@ const wash = require('./libs/wash')
 class Whale {
   constructor(interval, exchange, markets) {
     this.cacheData = {}
+    this.cacheExchange = {}
 
     this.fetchPrice(exchange, markets).then((data) => {
       this.screen = blessed.screen()
       this.grid = new contrib.grid({ rows: 12, cols: 12, screen: this.screen })
       this.cacheData = data
+      this.cacheExchange = exchange;
 
       this.initDashBoard(data, exchange)
       this.eventListeners(interval, exchange, markets)
@@ -84,7 +86,7 @@ class Whale {
 
     this.screen.on('resize', () => {
       utils.throttle(() => {
-        this.initDashBoard(this.cacheData)
+        this.initDashBoard(this.cacheData, this.cacheExchange)
       }, 360)()
     })
 

--- a/libs/args.js
+++ b/libs/args.js
@@ -5,6 +5,7 @@ args
   .description('Whale, show Ethereum and Bitcoin price in command line interface (CLI).')
   .option('-s, --seconds <number>', 'Set auto refresh time', parseInt)
   .option('-c, --config <configfile>', 'Use custom exchangers config')
+  .option('-a, --all', 'Use all markets configured for selected exchange')
 
 args.on('--help', () => {
   console.log('  Examples:')

--- a/libs/args.js
+++ b/libs/args.js
@@ -4,6 +4,7 @@ args
   .version('0.0.1')
   .description('Whale, show Ethereum and Bitcoin price in command line interface (CLI).')
   .option('-s, --seconds <number>', 'Set auto refresh time', parseInt)
+  .option('-c, --config <configfile>', 'Use custom exchangers config')
 
 args.on('--help', () => {
   console.log('  Examples:')

--- a/libs/fetch/bitfinex.js
+++ b/libs/fetch/bitfinex.js
@@ -1,22 +1,21 @@
 const request = require('superagent')
 const format = require('../format')
-const exchangers = require('../../config/exchangers')
 
 // Bitfinex
 exports.bitfinexCurrentPrice = function(exchange, markets) {
   const marketPairs = []
 
   markets.map((item) => {
-    Object.keys(exchangers[exchange].markets).map((market) => {
+    Object.keys(exchange.markets).map((market) => {
       if (item === market) {
-        marketPairs.push([exchangers[exchange].markets[market], market])
+        marketPairs.push([exchange.markets[market], market])
       }
     })
   })
 
   const promiseList = marketPairs.map((market) => {
     return new Promise((resolve, reject) => {
-      request(`${exchangers[exchange].ticker}/${market[0]}`)
+      request(`${exchange.ticker}/${market[0]}`)
       .end((err, res) => {
         if (!err) {
           resolve({ name: market[1], last: res.body[6], percentChange: res.body[5]})
@@ -38,7 +37,7 @@ exports.bitfinexCurrentPrice = function(exchange, markets) {
 
 exports.bitfinexPriceTrend = function(exchange, market, since, period) {
   return new Promise((resolve, reject) => {
-    request(`${exchangers[exchange].kendpoint}:${period}:${exchangers[exchange].markets[market]}/hist`)
+    request(`${exchange.kendpoint}:${period}:${exchange.markets[market]}/hist`)
     .query({ start: since })
     .end((err, res) => {
       if (!err) {

--- a/libs/fetch/coinbase.js
+++ b/libs/fetch/coinbase.js
@@ -1,6 +1,5 @@
 const request = require('superagent')
 const format = require('../format')
-const exchangers = require('../../config/exchangers')
 
 // Coinbase
 exports.coinbaseCurrentPrice = function(exchange, markets) {
@@ -28,7 +27,7 @@ exports.coinbaseCurrentPrice = function(exchange, markets) {
 exports.coinbasePriceTrend = function(exchange, market, since, period) {
   const end = new Date().toISOString()
   return new Promise((resolve, reject) => {
-    request(`${exchangers[exchange].kendpoint}/${exchangers[exchange].markets[market]}/candles`)
+    request(`${exchange.kendpoint}/${exchange.markets[market]}/candles`)
     .query({ start: since, end: end, granularity: period })
     .end((err, res) => {
       if (!err) {
@@ -45,16 +44,16 @@ function coinbaseLastPrice(exchange, markets) {
   const marketPairs = []
 
   markets.map((item) => {
-    Object.keys(exchangers[exchange].markets).map((market) => {
+    Object.keys(exchange.markets).map((market) => {
       if (item === market) {
-        marketPairs.push([exchangers[exchange].markets[market], market])
+        marketPairs.push([exchange.markets[market], market])
       }
     })
   })
 
   const promiseList = marketPairs.map((market) => {
     return new Promise((resolve, reject) => {
-      request(`${exchangers[exchange].ticker}/${market[0]}/ticker`)
+      request(`${exchange.ticker}/${market[0]}/ticker`)
       .end((err, res) => {
         if (!err) {
           resolve({ name: market[1], last: res.body.price, percentChange: 0})
@@ -80,7 +79,7 @@ function coinbaseOpenPrice(exchange, markets) {
 
   const promiseList = markets.map((market) => {
     return new Promise((resolve, reject) => {
-      request(`${exchangers[exchange].kendpoint}/${exchangers[exchange].markets[market]}/candles`)
+      request(`${exchange.kendpoint}/${exchange.markets[market]}/candles`)
       .query({ start: tsOpen, granularity: 86400 })
       .end((err, res) => {
         if (!err) {

--- a/libs/fetch/kraken.js
+++ b/libs/fetch/kraken.js
@@ -1,20 +1,19 @@
 const request = require('superagent')
 const format = require('../format')
-const exchangers = require('../../config/exchangers')
 
 // Kraken
 exports.krakenCurrentPrice = function(exchange, markets) {
   const marketPairs = []
   markets.map((item) => {
-    Object.keys(exchangers[exchange].markets).map((market) => {
+    Object.keys(exchange.markets).map((market) => {
       if (item === market) {
-        marketPairs.push(exchangers[exchange].markets[market])
+        marketPairs.push(exchange.markets[market])
       }
     })
   })
 
   return new Promise((resolve, reject) => {
-    request(exchangers[exchange].ticker)
+    request(exchange.ticker)
     .query({ pair: marketPairs.join(',') })
     .end((err, res) => {
       if (!err) {
@@ -28,9 +27,9 @@ exports.krakenCurrentPrice = function(exchange, markets) {
 }
 
 exports.krakenPriceTrend = function(exchange, market, since, period) {
-  const pair = exchangers[exchange].markets[market]
+  const pair = exchange.markets[market]
   return new Promise((resolve, reject) => {
-    request(exchangers[exchange].kendpoint)
+    request(exchange.kendpoint)
     .query({ pair: pair, since: since, interval: period })
     .end((err, res) => {
       if (!err) {

--- a/libs/fetch/poloniex.js
+++ b/libs/fetch/poloniex.js
@@ -1,11 +1,10 @@
 const request = require('superagent')
 const format = require('../format')
-const exchangers = require('../../config/exchangers')
 
 // Poloniex
 exports.poloniexCurrentPrice = function(exchange, markets) {
   return new Promise((resolve, reject) => {
-    request(exchangers[exchange].ticker).end((err, res) => {
+    request(exchange.ticker).end((err, res) => {
       if (!err) {
         const formatData = format.currentPrice(res.body, exchange, markets)
         resolve(formatData)
@@ -18,8 +17,8 @@ exports.poloniexCurrentPrice = function(exchange, markets) {
 
 exports.poloniexPriceTrend = function(exchange, market, since, period) {
   return new Promise((resolve, reject) => {
-    request(exchangers[exchange].kendpoint)
-    .query({ currencyPair: exchangers[exchange].markets[market], period: period, start: since })
+    request(exchange.kendpoint)
+    .query({ currencyPair: exchange.markets[market], period: period, start: since })
     .end((err, res) => {
       if (!err) {
         const formatData = format.priceTrend(res.body, exchange, market)

--- a/libs/fetch/yunbi.js
+++ b/libs/fetch/yunbi.js
@@ -1,6 +1,5 @@
 const request = require('superagent')
 const format = require('../format')
-const exchangers = require('../../config/exchangers')
 
 // Yunbi
 exports.yunbiCurrentPrice = function(exchange, markets) {
@@ -27,8 +26,8 @@ exports.yunbiCurrentPrice = function(exchange, markets) {
 
 exports.yunbiPriceTrend = function(exchange, market, since, period) {
   return new Promise((resolve, reject) => {
-    request(exchangers[exchange].kendpoint)
-    .query({ market: exchangers[exchange].markets[market], timestamp: since, period: period })
+    request(exchange.kendpoint)
+    .query({ market: exchange.markets[market], timestamp: since, period: period })
     .end((err, res) => {
       if (!err) {
         const formatData = format.priceTrend(res.body, exchange, market)
@@ -42,7 +41,7 @@ exports.yunbiPriceTrend = function(exchange, market, since, period) {
 
 function yunbiLastPrice(exchange, markets) {
   return new Promise((resolve, reject) => {
-    request(exchangers[exchange].ticker).end((err, res) => {
+    request(exchange.ticker).end((err, res) => {
       if (!err) {
         const formatData = format.currentPrice(res.body, exchange, markets)
         resolve(formatData)
@@ -59,8 +58,8 @@ function yunbiOpenPrice(exchange, markets) {
 
   const promiseList = markets.map((market) => {
     return new Promise((resolve, reject) => {
-      request(exchangers[exchange].kendpoint)
-      .query({ market: exchangers[exchange].markets[market], limit: 1, period: 1, timestamp: tsOpen })
+      request(exchange.kendpoint)
+      .query({ market: exchange.markets[market], limit: 1, period: 1, timestamp: tsOpen })
       .end((err, res) => {
         if (!err) {
           resolve({ name: market, open: res.body[0][1] })

--- a/libs/format.js
+++ b/libs/format.js
@@ -1,12 +1,11 @@
 const utils = require('./utils')
-const exchangers = require('../config/exchangers')
 
 exports.currentPrice = function(res = {}, exchange, markets) {
   const currentPriceList = []
 
   Object.keys(res).map((item) => {
     markets.map((market) => {
-      if (item === exchangers[exchange].markets[market]) {
+      if (item === exchange.markets[market]) {
         const last = formatLast(exchange, res, item)
         const percentChange = formatPercentChange(exchange, res, item)
 
@@ -41,7 +40,7 @@ exports.priceTrend = function(res = [], exchange, currentMarket) {
 function formatLast(exchange, data, market) {
   let last = 0
 
-  switch (exchange) {
+  switch (exchange.name) {
     case 'Poloniex':
       last = data[market].last
       break;
@@ -64,7 +63,7 @@ function formatLast(exchange, data, market) {
 function formatPercentChange(exchange, data, market) {
   let percentChange = 0
 
-  switch (exchange) {
+  switch (exchange.name) {
     case 'Poloniex':
       percentChange = data[market].percentChange
       break;
@@ -87,7 +86,7 @@ function formatPercentChange(exchange, data, market) {
 function formatClose(exchange, record) {
   let close = 0
 
-  switch (exchange) {
+  switch (exchange.name) {
     case 'Poloniex':
       close = record.close
       break;
@@ -113,7 +112,7 @@ function formatClose(exchange, record) {
 function formatDate(exchange, record) {
   let date = 0
 
-  switch (exchange) {
+  switch (exchange.name) {
     case 'Poloniex':
       date = record.date
       break;

--- a/libs/prompt.js
+++ b/libs/prompt.js
@@ -2,21 +2,39 @@ const inquirer = require('inquirer');
 
 let exchangeSelected = ''
 
-const prompt = (exchangers) => {
+const prompt = (exchangers, allMarkets) => {
   return new Promise((resolve, reject) => {
-    inquirer.prompt({
-      type: 'list',
-      name: 'exchange',
-      message: 'Select your favorite exchange?',
-      choices: Object.keys(exchangers),
-      validate: function (answer) {
-        if (answer.length < 1) {
-          return 'You must choose at least one exchange.'
+    // Continue with only configured market, or prompt user.
+    let exchangeSelect;
+    if (Object.keys(exchangers).length < 2) {
+      exchangeSelect = new Promise((resolve) => {
+        resolve({exchange: Object.keys(exchangers)[0]});
+      });
+    } else {
+      exchangeSelect = inquirer.prompt({
+        type: 'list',
+        name: 'exchange',
+        message: 'Select your favorite exchange?',
+        choices: Object.keys(exchangers),
+        validate: function (answer) {
+          if (answer.length < 1) {
+            return 'You must choose at least one exchange.'
+          }
+          return true
         }
-        return true
-      }
-    }).then((answer) => {
+      });
+    }
+
+    exchangeSelect.then((answer) => {
       exchangeSelected = answer.exchange
+
+      // Continue with all markets or prompt user.
+      if (allMarkets) {
+        return resolve({
+          exchange: exchangeSelected,
+          markets: Object.keys(exchangers[answer.exchange].markets)
+        });
+      }
 
       inquirer.prompt({
         type: 'checkbox',

--- a/libs/prompt.js
+++ b/libs/prompt.js
@@ -1,41 +1,42 @@
-const inquirer = require('inquirer')
-const exchangers = require('../config/exchangers.json')
+const inquirer = require('inquirer');
 
 let exchangeSelected = ''
 
-const prompt = new Promise((resolve, reject) => {
-  inquirer.prompt({
-    type: 'list',
-    name: 'exchange',
-    message: 'Select your favorite exchange?',
-    choices: Object.keys(exchangers),
-    validate: function (answer) {
-      if (answer.length < 1) {
-        return 'You must choose at least one exchange.'
-      }
-      return true
-    }
-  }).then((answer) => {
-    exchangeSelected = answer.exchange
-
+const prompt = (exchangers) => {
+  return new Promise((resolve, reject) => {
     inquirer.prompt({
-      type: 'checkbox',
-      name: 'markets',
-      message: 'And your favorite market?',
-      choices: Object.keys(exchangers[answer.exchange].markets),
+      type: 'list',
+      name: 'exchange',
+      message: 'Select your favorite exchange?',
+      choices: Object.keys(exchangers),
       validate: function (answer) {
         if (answer.length < 1) {
-          return 'You must choose at least one market.';
+          return 'You must choose at least one exchange.'
         }
         return true
       }
     }).then((answer) => {
-      resolve({
-        exchange: exchangeSelected,
-        markets: answer.markets
+      exchangeSelected = answer.exchange
+
+      inquirer.prompt({
+        type: 'checkbox',
+        name: 'markets',
+        message: 'And your favorite market?',
+        choices: Object.keys(exchangers[answer.exchange].markets),
+        validate: function (answer) {
+          if (answer.length < 1) {
+            return 'You must choose at least one market.';
+          }
+          return true
+        }
+      }).then((answer) => {
+        resolve({
+          exchange: exchangeSelected,
+          markets: answer.markets
+        })
       })
     })
   })
-})
+}
 
 module.exports = prompt

--- a/libs/sea.js
+++ b/libs/sea.js
@@ -1,17 +1,17 @@
-const exchangers = require('../config/exchangers')
+/*jshint -W018 */ // confusing use of '!'
 const fetch = require('./fetch')
 
 exports.getCurrentPrice = function(exchange, markets) {
-  if (!exchange instanceof String) {
-    return Promise.reject('TypeError: exchange should be an string type')
+  if (!exchange instanceof Object) {
+    return Promise.reject('TypeError: exchange should be an object type')
   }
 
-  if (!markets instanceof Array) {
+  if (!markets instanceof Array) { // jshint ignore:line
     return Promise.reject('TypeError: markets should be an array type')
   }
 
   if (hasMarkets(exchange, markets)) {
-    switch (exchange) {
+    switch (exchange.name) {
       case 'Poloniex':
         return fetch.poloniexCurrentPrice(exchange, markets)
       case 'Kraken':
@@ -31,8 +31,8 @@ exports.getCurrentPrice = function(exchange, markets) {
 }
 
 exports.getPriceTrend = function(exchange, market, customSince, customPeriod) {
-  if (!exchange instanceof String) {
-    return Promise.reject('TypeError: exchange should be an string type')
+  if (!exchange instanceof Object) {
+    return Promise.reject('TypeError: exchange should be an object type')
   }
 
   if (!market instanceof String) {
@@ -45,7 +45,7 @@ exports.getPriceTrend = function(exchange, market, customSince, customPeriod) {
   const period = customPeriod || defaultPeriod
 
   if (hasMarkets(exchange, market)) {
-    switch (exchange) {
+    switch (exchange.name) {
       case 'Poloniex':
         return fetch.poloniexPriceTrend(exchange, market, since, period)
       case 'Kraken':
@@ -65,9 +65,9 @@ exports.getPriceTrend = function(exchange, market, customSince, customPeriod) {
 }
 
 function hasMarkets(exchange, markets) {
-  const exchangeMarkets = Object.keys(exchangers[exchange].markets)
+  const exchangeMarkets = Object.keys(exchange.markets)
 
-  if (typeof markets === 'array') {
+  if (typeof markets === 'array') { // jshint ignore:line
     markets.forEach((market) => {
       if (!exchangeMarkets.includes(market)) return false
     })
@@ -85,7 +85,7 @@ function filterDefaultSince(exchange) {
   const monthAgoMilliSecond = Math.round(new Date().getTime()) - (30 * 24 * 3600 * 1000)
   let since = monthAgoSencond
 
-  switch (exchange) {
+  switch (exchange.name) {
     case 'Poloniex':
       since = monthAgoSencond
       break;
@@ -111,7 +111,7 @@ function filterDefaultSince(exchange) {
 function filterDefaultPeriod(exchange) {
   let period = 1440
 
-  switch (exchange) {
+  switch (exchange.name) {
     case 'Poloniex':
       period = 86400 // 86400 / 60 / 60 = 24
       break;

--- a/libs/wash.js
+++ b/libs/wash.js
@@ -1,5 +1,4 @@
 const utils = require('./utils')
-const exchangers = require('../config/exchangers')
 
 exports.currentPrice = function(exchange, priceList) {
   return priceList.map((price) => {
@@ -7,7 +6,7 @@ exports.currentPrice = function(exchange, priceList) {
     ? `- ${utils.formatDecimal(-price.percentChange * 100, 2)}%`
     : `+ ${utils.formatDecimal(price.percentChange * 100, 2)}%`
 
-    const last = `${exchangers[exchange].currency} ${price.last}`
+    const last = `${exchange.currency} ${price.last}`
 
     return [price.name, last, change]
   })


### PR DESCRIPTION
I too wanted EUR instead of USD as requested in issue #2. Here is a PR that:

- adds `-c, --config`, to specify custom configuration. Change markets and currency symbol to use any currency supported by the exchange. If the configuration contains only one exchange, it is selected automatically.
- adds `-a, --all`, to select all markets from the selected exchange.

With these two combined one can start Whale directly without having to always choose an exchange or markets.

To achieve this I have removed the `require` of the built-in config file everywhere but `bin/cli.js`, and instantiated Whale with only the selected exchange configuration, which is passed around to whoever needs it. This makes sense IMO, since one Whale instance can not (and should not?) switch exchanges at run time. Whale is now instantiated with everything it needs to function.

Cheers, and thanks for this lib.